### PR TITLE
Add to the CLI arguments of drop

### DIFF
--- a/ros2bag_tools/ros2bag_tools/filter/drop.py
+++ b/ros2bag_tools/ros2bag_tools/filter/drop.py
@@ -60,11 +60,12 @@ class DropFilter(FilterExtension):
     def filter_msg(self, msg):
         (topic, _, _) = msg
 
-        if topic not in self._msg_counters:
-            self._msg_counters[topic] = 0
-
         if self._is_drop_topic(topic):
             do_drop = False
+
+            if topic not in self._msg_counters:
+                self._msg_counters[topic] = 0
+
             if self._msg_counters[topic] >= self._y:
                 self._msg_counters[topic] = 0
             if self._msg_counters[topic] < self._x:

--- a/ros2bag_tools/ros2bag_tools/filter/drop.py
+++ b/ros2bag_tools/ros2bag_tools/filter/drop.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable, Sequence
+from typing import Sequence
 from ros2bag_tools.filter import FilterExtension
 from ros2bag_tools.filter import FilterResult
 
@@ -51,7 +51,6 @@ class DropFilter(FilterExtension):
 
     def _is_drop_topic(self, topic: str) -> bool:
         """Return a boolean indicating whether we're interested in filtering this topic."""
-
         if len(self._topics) == 1 and self._topics[0] == "all":
             return True
 

--- a/ros2bag_tools/ros2bag_tools/filter/drop.py
+++ b/ros2bag_tools/ros2bag_tools/filter/drop.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Sequence
+from typing import Dict, Sequence
 from ros2bag_tools.filter import FilterExtension
 from ros2bag_tools.filter import FilterResult
 
@@ -25,7 +25,7 @@ class DropFilter(FilterExtension):
         self._topics: Sequence[str] = []
         self._x = 0
         self._y = 0
-        self._i = 0
+        self._msg_counters: Dict[str, int] = {}
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -59,13 +59,17 @@ class DropFilter(FilterExtension):
 
     def filter_msg(self, msg):
         (topic, _, _) = msg
+
+        if topic not in self._msg_counters:
+            self._msg_counters[topic] = 0
+
         if self._is_drop_topic(topic):
             do_drop = False
-            if self._i >= self._y:
-                self._i = 0
-            if self._i < self._x:
+            if self._msg_counters[topic] >= self._y:
+                self._msg_counters[topic] = 0
+            if self._msg_counters[topic] < self._x:
                 do_drop = True
-            self._i += 1
+            self._msg_counters[topic] += 1
             if do_drop:
                 return FilterResult.DROP_MESSAGE
 

--- a/ros2bag_tools/ros2bag_tools/filter/drop.py
+++ b/ros2bag_tools/ros2bag_tools/filter/drop.py
@@ -21,6 +21,7 @@ class DropFilter(FilterExtension):
     """Drop X out every Y message of a topic."""
 
     def __init__(self):
+        super().__init__(self)
         self._topics: Sequence[str] = []
         self._x = 0
         self._y = 0

--- a/ros2bag_tools/test/test_filter.py
+++ b/ros2bag_tools/test/test_filter.py
@@ -20,6 +20,7 @@ from rosbag2_py import Info, TopicMetadata
 from ros2bag_tools.filter import FilterResult
 from ros2bag_tools.filter.add import AddFilter
 from ros2bag_tools.filter.cut import CutFilter
+from ros2bag_tools.filter.drop import DropFilter
 from ros2bag_tools.filter.extract import ExtractFilter
 from ros2bag_tools.filter.reframe import ReframeFilter
 from ros2bag_tools.filter.rename import RenameFilter
@@ -73,6 +74,36 @@ def test_add_filter():
     assert(t0 == t1)
     assert(deserialize_message(data0, String).data == 'align')
     assert(deserialize_message(data1, String).data == 'out')
+
+
+def test_drop_filter():
+    filter = DropFilter()
+    y = 10
+    x = 4
+
+    parser = argparse.ArgumentParser('drop')
+    filter.add_arguments(parser)
+    args = parser.parse_args(['-t', '/data1', '/data2', '-x', '4', '-y', '10'])
+    filter.set_args(None, args)
+
+
+    msg1 = ('/data1', None, 0)
+    msg2 = ('/data2', None, 0)
+
+    msg_other = ('/data3', None, 0)
+
+    for i in range(y):
+        for j in range(0, y, 2):
+            assert(filter.filter_msg(msg_other) == msg_other)
+            if j < x:
+                assert(filter.filter_msg(msg1) == FilterResult.DROP_MESSAGE)
+                assert(filter.filter_msg(msg2) == FilterResult.DROP_MESSAGE)
+            else:
+                assert(filter.filter_msg(msg1) == msg1)
+                assert(filter.filter_msg(msg2) == msg2)
+
+    msg = ('/data', None, 0)
+    assert(filter.filter_msg(msg) == msg)
 
 
 def test_extract_filter():

--- a/ros2bag_tools/test/test_filter.py
+++ b/ros2bag_tools/test/test_filter.py
@@ -86,14 +86,13 @@ def test_drop_filter():
     args = parser.parse_args(['-t', '/data1', '/data2', '-x', '4', '-y', '10'])
     filter.set_args(None, args)
 
-
     msg1 = ('/data1', None, 0)
     msg2 = ('/data2', None, 0)
 
     msg_other = ('/data3', None, 0)
 
     for i in range(y):
-        for j in range(0, y, 2):
+        for j in range(y):
             assert(filter.filter_msg(msg_other) == msg_other)
             if j < x:
                 assert(filter.filter_msg(msg1) == FilterResult.DROP_MESSAGE)


### PR DESCRIPTION
Enable the user to pass multiple topics to `ros2 bag drop -t`. They can specify t hem sequentially, one after the other `-t topic1 topic2 ...`. The user can also specify the special `all` - `-t all` in order to drop messages from all the topics in the given bag.

P.S. Thanks for this very useful tool!