### PR TITLE
Add multi-topic rename support to RenameFilter

### DIFF
--- a/ros2bag_tools/ros2bag_tools/filter/rename.py
+++ b/ros2bag_tools/ros2bag_tools/filter/rename.py
@@ -22,24 +22,26 @@ class RenameFilter(FilterExtension):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            '-t', '--topic', 
-            action='append', 
+            '-t', '--topic',
+            action='append',
             dest='topics',
             required=True,
-            help='Topic to rename. Can be specified multiple times with corresponding --name arguments.'
+            help='Topic to rename. Can be specified multiple times with corresponding --name '
+                 'arguments.'
         )
         parser.add_argument(
-            '--name', 
-            action='append', 
+            '--name',
+            action='append',
             dest='names',
             required=True,
-            help='New name to set. Can be specified multiple times with corresponding --topic arguments.'
+            help='New name to set. Can be specified multiple times with corresponding --topic '
+                 'arguments.'
         )
 
     def set_args(self, _metadata, args):
         if len(args.topics) != len(args.names):
             raise ValueError('Number of topics must match number of names')
-        
+
         self._rename_map = dict(zip(args.topics, args.names))
 
     def filter_topic(self, topic_metadata):


### PR DESCRIPTION
Hello! Thanks for the great tool!

I found it more convenient to rename multiple topics in a single call, so I made a slight modification to the rename filter.

Example usage:

```
ros2 bag rename \
    -o /path/to/renamed_bag_dir \
    -t /original_topic_name --name /new_topic_name \
    -t /original_topic_name2 --name /new_topic_name2 \
    /path/to/bag_dir/
```