### PR TITLE
Drop messages by ratio instead of counter

### DIFF
--- a/ros2bag_tools/ros2bag_tools/filter/drop.py
+++ b/ros2bag_tools/ros2bag_tools/filter/drop.py
@@ -14,7 +14,6 @@
 
 from typing import Dict, Sequence
 
-from ros2bag.api import print_error
 from ros2bag_tools.filter import FilterExtension, FilterResult
 
 
@@ -38,27 +37,27 @@ class DropFilter(FilterExtension):
             ),
         )
         parser.add_argument(
-            "-x",
+            '-x',
             type=int,
             required=True,
-            help="Count of messages out of y to drop. Must be > 0.",
+            help='Count of messages out of y to drop. Must be > 0.',
         )
         parser.add_argument(
-            "-y",
+            '-y',
             type=int,
             required=True,
-            help="Module of the message counter. Must be > 0 and => x.",
+            help='Module of the message counter. Must be > 0 and => x.',
         )
 
     def set_args(self, _metadata, args):
         if not args.y > 0:
-            print(print_error("y must be > 0"))
+            self._logger.error('y must be > 0')
             exit(1)
         if not args.x > 0:
-            print(print_error("x must be > 0"))
+            self._logger.error('x must be > 0')
             exit(1)
         if not args.y >= args.x:
-            print(print_error("y must be => x"))
+            self._logger.error('y must be => x')
             exit(1)
 
         self._topics = args.topics
@@ -78,23 +77,23 @@ class DropFilter(FilterExtension):
         if self._is_drop_topic(topic):
             # initialize counters
             if topic not in self._msg_counters:
-                self._msg_counters[topic] = {"total": 0, "dropped": 0}
+                self._msg_counters[topic] = {'total': 0, 'dropped': 0}
 
             # reset counters if we have reached sample size
-            if self._msg_counters[topic]["total"] == self._sample_size:
-                self._msg_counters[topic] = {"total": 0, "dropped": 0}
+            if self._msg_counters[topic]['total'] == self._sample_size:
+                self._msg_counters[topic] = {'total': 0, 'dropped': 0}
 
-            self._msg_counters[topic]["total"] += 1
+            self._msg_counters[topic]['total'] += 1
 
             # calculate current dropped messages ratio
             ratio = (
-                self._msg_counters[topic]["dropped"]
-                / self._msg_counters[topic]["total"]
+                self._msg_counters[topic]['dropped']
+                / self._msg_counters[topic]['total']
             )
 
             # drop message if we are currently below target ratio
             if ratio < self._ratio:
-                self._msg_counters[topic]["dropped"] += 1
+                self._msg_counters[topic]['dropped'] += 1
                 return FilterResult.DROP_MESSAGE
 
         return msg

--- a/ros2bag_tools/ros2bag_tools/filter/drop.py
+++ b/ros2bag_tools/ros2bag_tools/filter/drop.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from fractions import Fraction
 from typing import Dict, Sequence
 
 from ros2bag_tools.filter import FilterExtension, FilterResult
@@ -23,7 +24,7 @@ class DropFilter(FilterExtension):
     def __init__(self):
         super().__init__()
         self._topics: Sequence[str] = []
-        self._ratio: float = 1.0
+        self._ratio: Fraction = Fraction(1)
         self._msg_counters: Dict[str, Dict[str, int]] = {}
 
     def add_arguments(self, parser):
@@ -39,30 +40,48 @@ class DropFilter(FilterExtension):
         parser.add_argument(
             '-x',
             type=int,
-            required=True,
-            help='Count of messages out of y to drop. Must be > 0.',
+            required=False,
+            help='Count of messages out of y to drop. Must be > 0. '
+            'Requires y to be set and ratio to be unset.',
+            default=-1
         )
         parser.add_argument(
             '-y',
             type=int,
-            required=True,
-            help='Module of the message counter. Must be > 0 and => x.',
+            required=False,
+            help='Module of the message counter. Must be > 0 and => x. '
+            'Requires x to be set and ratio to be unset.',
+            default=-1
+        )
+        parser.add_argument(
+            '-r', '--ratio',
+            type=Fraction,
+            required=False,
+            help='Ratio of messages to drop. '
+            'Can be specified as x/y or as number with decimal places. '
+            'Must be > 0 and => 1. Overrules x and y arguments.',
+            default=None
         )
 
     def set_args(self, _metadata, args):
-        if not args.y > 0:
-            self._logger.error('y must be > 0')
-            exit(1)
-        if not args.x > 0:
-            self._logger.error('x must be > 0')
-            exit(1)
-        if not args.y >= args.x:
-            self._logger.error('y must be => x')
-            exit(1)
+        if args.ratio is None:
+            if not args.y > 0:
+                self._logger.error('y must be > 0')
+                exit(1)
+            if not args.x > 0:
+                self._logger.error('x must be > 0')
+                exit(1)
+            if not args.y >= args.x:
+                self._logger.error('y must be => x')
+                exit(1)
+            self._ratio = Fraction(args.x, args.y)
+        else:
+            if args.ratio < 0 or args.ratio > 1:
+                self._logger.error('ratio must be > 0 and <= 1')
+                exit(1)
+            self._ratio = args.ratio
 
         self._topics = args.topics
-        self._ratio = args.x / args.y
-        self._sample_size = args.y
 
     def _is_drop_topic(self, topic: str) -> bool:
         """Return a boolean indicating whether we're interested in filtering this topic."""
@@ -79,16 +98,12 @@ class DropFilter(FilterExtension):
             if topic not in self._msg_counters:
                 self._msg_counters[topic] = {'total': 0, 'dropped': 0}
 
-            # reset counters if we have reached sample size
-            if self._msg_counters[topic]['total'] == self._sample_size:
-                self._msg_counters[topic] = {'total': 0, 'dropped': 0}
-
             self._msg_counters[topic]['total'] += 1
 
             # calculate current dropped messages ratio
-            ratio = (
-                self._msg_counters[topic]['dropped']
-                / self._msg_counters[topic]['total']
+            ratio = Fraction(
+                self._msg_counters[topic]['dropped'],
+                self._msg_counters[topic]['total']
             )
 
             # drop message if we are currently below target ratio

--- a/ros2bag_tools/ros2bag_tools/filter/drop.py
+++ b/ros2bag_tools/ros2bag_tools/filter/drop.py
@@ -49,7 +49,7 @@ class DropFilter(FilterExtension):
             '-y',
             type=int,
             required=False,
-            help='Module of the message counter. Must be > 0 and => x. '
+            help='Module of the message counter. Must be > 0 and >= x. '
             'Requires x to be set and ratio to be unset.',
             default=-1
         )
@@ -72,11 +72,11 @@ class DropFilter(FilterExtension):
                 self._logger.error('x must be > 0')
                 exit(1)
             if not args.y >= args.x:
-                self._logger.error('y must be => x')
+                self._logger.error('y must be >= x')
                 exit(1)
             self._ratio = Fraction(args.x, args.y)
         else:
-            if args.ratio < 0 or args.ratio > 1:
+            if args.ratio <= 0 or args.ratio > 1:
                 self._logger.error('ratio must be > 0 and <= 1')
                 exit(1)
             self._ratio = args.ratio

--- a/ros2bag_tools/ros2bag_tools/filter/drop.py
+++ b/ros2bag_tools/ros2bag_tools/filter/drop.py
@@ -14,8 +14,8 @@
 
 from typing import Dict, Sequence
 
-from ros2bag_tools.filter import FilterExtension
-from ros2bag_tools.filter import FilterResult
+from ros2bag.api import print_error
+from ros2bag_tools.filter import FilterExtension, FilterResult
 
 
 class DropFilter(FilterExtension):
@@ -24,9 +24,8 @@ class DropFilter(FilterExtension):
     def __init__(self):
         super().__init__()
         self._topics: Sequence[str] = []
-        self._x = 0
-        self._y = 0
-        self._msg_counters: Dict[str, int] = {}
+        self._ratio: float = 1.0
+        self._msg_counters: Dict[str, Dict[str, int]] = {}
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -39,17 +38,32 @@ class DropFilter(FilterExtension):
             ),
         )
         parser.add_argument(
-            '-x', type=int, required=True, help='count of messages out of ytodrop'
+            "-x",
+            type=int,
+            required=True,
+            help="Count of messages out of y to drop. Must be > 0.",
         )
         parser.add_argument(
-            '-y', type=int, required=True, help='module of the message counter'
+            "-y",
+            type=int,
+            required=True,
+            help="Module of the message counter. Must be > 0 and => x.",
         )
 
     def set_args(self, _metadata, args):
+        if not args.y > 0:
+            print(print_error("y must be > 0"))
+            exit(1)
+        if not args.x > 0:
+            print(print_error("x must be > 0"))
+            exit(1)
+        if not args.y >= args.x:
+            print(print_error("y must be => x"))
+            exit(1)
+
         self._topics = args.topics
-        self._x = args.x
-        self._y = args.y
-        assert self._x <= self._y
+        self._ratio = args.x / args.y
+        self._sample_size = args.y
 
     def _is_drop_topic(self, topic: str) -> bool:
         """Return a boolean indicating whether we're interested in filtering this topic."""
@@ -62,17 +76,25 @@ class DropFilter(FilterExtension):
         (topic, _, _) = msg
 
         if self._is_drop_topic(topic):
-            do_drop = False
-
+            # initialize counters
             if topic not in self._msg_counters:
-                self._msg_counters[topic] = 0
+                self._msg_counters[topic] = {"total": 0, "dropped": 0}
 
-            if self._msg_counters[topic] >= self._y:
-                self._msg_counters[topic] = 0
-            if self._msg_counters[topic] < self._x:
-                do_drop = True
-            self._msg_counters[topic] += 1
-            if do_drop:
+            # reset counters if we have reached sample size
+            if self._msg_counters[topic]["total"] == self._sample_size:
+                self._msg_counters[topic] = {"total": 0, "dropped": 0}
+
+            self._msg_counters[topic]["total"] += 1
+
+            # calculate current dropped messages ratio
+            ratio = (
+                self._msg_counters[topic]["dropped"]
+                / self._msg_counters[topic]["total"]
+            )
+
+            # drop message if we are currently below target ratio
+            if ratio < self._ratio:
+                self._msg_counters[topic]["dropped"] += 1
                 return FilterResult.DROP_MESSAGE
 
         return msg

--- a/ros2bag_tools/test/test_filter.py
+++ b/ros2bag_tools/test/test_filter.py
@@ -99,21 +99,28 @@ def test_drop_filter():
 
     msg1 = ('/data1', None, 0)
     msg2 = ('/data2', None, 0)
-
     msg_other = ('/data3', None, 0)
 
-    for i in range(y):
-        for j in range(y):
-            assert (test_filter.filter_msg(msg_other) == msg_other)
-            if j < x:
-                assert (test_filter.filter_msg(msg1) == FilterResult.DROP_MESSAGE)
-                assert (test_filter.filter_msg(msg2) == FilterResult.DROP_MESSAGE)
-            else:
-                assert (test_filter.filter_msg(msg1) == msg1)
-                assert (test_filter.filter_msg(msg2) == msg2)
+    dropped1 = 0
+    dropped2 = 0
+    dropped_other = 0
 
-    msg = ('/data', None, 0)
-    assert (test_filter.filter_msg(msg) == msg)
+    total = y * x
+    for i in range(total):
+        if test_filter.filter_msg(msg1) == FilterResult.DROP_MESSAGE:
+            dropped1 += 1
+        if test_filter.filter_msg(msg2) == FilterResult.DROP_MESSAGE:
+            dropped2 += 1
+        if test_filter.filter_msg(msg_other) == FilterResult.DROP_MESSAGE:
+            dropped_other += 1
+
+    for i in range(y):
+        if test_filter.filter_msg(msg1) == FilterResult.DROP_MESSAGE:
+            dropped1 += 1
+
+    assert (dropped1 == (total * (x / y)) + (y * (x / y)))
+    assert (dropped2 == total * (x / y))
+    assert (dropped_other == 0)
 
 
 def test_extract_filter():

--- a/ros2bag_tools/test/test_filter.py
+++ b/ros2bag_tools/test/test_filter.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import argparse
+from fractions import Fraction
 import logging
 from pathlib import Path
 
@@ -92,35 +93,44 @@ def test_drop_filter():
     y = 10
     x = 4
 
-    parser = argparse.ArgumentParser('drop')
-    test_filter.add_arguments(parser)
-    args = parser.parse_args(['-t', '/data1', '/data2', '-x', '4', '-y', '10'])
-    test_filter.set_args(None, args)
-
     msg1 = ('/data1', None, 0)
     msg2 = ('/data2', None, 0)
     msg_other = ('/data3', None, 0)
 
-    dropped1 = 0
-    dropped2 = 0
-    dropped_other = 0
+    def perform_test():
+        dropped1 = 0
+        dropped2 = 0
+        dropped_other = 0
 
-    total = y * x
-    for i in range(total):
-        if test_filter.filter_msg(msg1) == FilterResult.DROP_MESSAGE:
-            dropped1 += 1
-        if test_filter.filter_msg(msg2) == FilterResult.DROP_MESSAGE:
-            dropped2 += 1
-        if test_filter.filter_msg(msg_other) == FilterResult.DROP_MESSAGE:
-            dropped_other += 1
+        total = y * x
+        for i in range(total):
+            if test_filter.filter_msg(msg1) == FilterResult.DROP_MESSAGE:
+                dropped1 += 1
+            if test_filter.filter_msg(msg2) == FilterResult.DROP_MESSAGE:
+                dropped2 += 1
+            if test_filter.filter_msg(msg_other) == FilterResult.DROP_MESSAGE:
+                dropped_other += 1
 
-    for i in range(y):
-        if test_filter.filter_msg(msg1) == FilterResult.DROP_MESSAGE:
-            dropped1 += 1
+        for i in range(y):
+            if test_filter.filter_msg(msg1) == FilterResult.DROP_MESSAGE:
+                dropped1 += 1
 
-    assert (dropped1 == (total * (x / y)) + (y * (x / y)))
-    assert (dropped2 == total * (x / y))
-    assert (dropped_other == 0)
+        assert (dropped1 == (total * Fraction(x, y)) + (y * Fraction(x, y)))
+        assert (dropped2 == total * Fraction(x, y))
+        assert (dropped_other == 0)
+
+    parser = argparse.ArgumentParser('drop')
+    test_filter.add_arguments(parser)
+
+    # perform test with x y arguments
+    args = parser.parse_args(['-t', '/data1', '/data2', '-x', str(x), '-y', str(y)])
+    test_filter.set_args(None, args)
+    perform_test()
+
+    # perform test with ratio argument
+    args = parser.parse_args(['-t', '/data1', '/data2', '-r', f'{x}/{y}'])
+    test_filter.set_args(None, args)
+    perform_test()
 
 
 def test_extract_filter():


### PR DESCRIPTION
Currently messages are dropped by a counter which leads to uneven message drops.

Example:
With X=15 and Y=30, the first 15 messages are dropped and the next 15 messages are kept.

This PR changes the filter to use a ratio instead of a counter, so the example from above will drop every second messages instead.